### PR TITLE
Add unified UI and instance utilities

### DIFF
--- a/buildingToolsUI.py
+++ b/buildingToolsUI.py
@@ -1,0 +1,199 @@
+# -*- coding: utf-8 -*-
+"""Unified UI for the instance placement helper scripts."""
+
+import maya.cmds as cmds
+
+import instanceArray
+import instanceChain
+import instanceRadial
+import instanceUtilities
+
+
+WINDOW_NAME = "buildingToolsWin"
+
+
+def _show_error(message):
+    cmds.inViewMessage(amg=f"<span style='color:#ffaaaa'>{message}</span>", pos="midCenter", fade=True)
+
+
+def show_ui():
+    """Display the Building Tools UI window."""
+    if cmds.window(WINDOW_NAME, exists=True):
+        cmds.deleteUI(WINDOW_NAME)
+
+    win = cmds.window(WINDOW_NAME, title=u"Building Tools", sizeable=False)
+    tabs = cmds.tabLayout(innerMarginWidth=8, innerMarginHeight=8)
+
+    # ------------------------------------------------------------------
+    # Array tab
+    # ------------------------------------------------------------------
+    array_tab = cmds.columnLayout(adj=True, rowSpacing=6, columnAttach=("both", 8))
+    cmds.text(label=u"選択：親(始点) → 子(終点)", align="left")
+    array_count = cmds.intFieldGrp(label=u"間に置く個数", value1=5, columnWidth=[(1, 100), (2, 60)])
+    array_include_end = cmds.checkBox(label=u"終点にも配置する", value=False)
+    array_orient = cmds.optionMenuGrp(label=u"向き", columnWidth=[(1, 100)])
+    cmds.menuItem(label=u"維持 (none)")
+    cmds.menuItem(label=u"終点方向 (aim)")
+    cmds.menuItem(label=u"コピー (copy)")
+    array_parent = cmds.checkBox(label=u"親(始点)の子にする", value=True)
+
+    def on_array_execute(*_):
+        try:
+            orient_idx = cmds.optionMenuGrp(array_orient, q=True, select=True)
+            orient_value = ["none", "aim", "copy"][orient_idx - 1]
+            result = instanceArray.instance_child_between_parent(
+                count=cmds.intFieldGrp(array_count, q=True, value1=True),
+                include_end=cmds.checkBox(array_include_end, q=True, value=True),
+                orient=orient_value,
+                parent_instances_to_parent=cmds.checkBox(array_parent, q=True, value=True),
+            )
+            if result:
+                cmds.inViewMessage(
+                    amg=u"<span style='color:#b0ffb0'>%d 個のインスタンスを作成しました。</span>" % len(result),
+                    pos="midCenter",
+                    fade=True,
+                )
+        except RuntimeError as exc:
+            _show_error(str(exc))
+
+    cmds.button(label=u"配置", command=on_array_execute, bgc=(0.6, 0.8, 0.6))
+    cmds.setParent("..")
+
+    # ------------------------------------------------------------------
+    # Chain tab
+    # ------------------------------------------------------------------
+    chain_tab = cmds.columnLayout(adj=True, rowSpacing=6, columnAttach=("both", 8))
+    cmds.text(label=u"選択：テンプレート → 対象2つ以上", align="left")
+    chain_count = cmds.intFieldGrp(label=u"各区間の個数", value1=1, columnWidth=[(1, 110), (2, 60)])
+
+    def on_parent_mode_changed(selection):
+        enable = selection == u"指定ノード"
+        cmds.textFieldGrp(chain_parent_target, e=True, enable=enable)
+
+    chain_parent_mode = cmds.optionMenuGrp(
+        label=u"親付け",
+        columnWidth=[(1, 110)],
+        changeCommand=on_parent_mode_changed,
+    )
+    cmds.menuItem(label=u"なし (ワールド)")
+    cmds.menuItem(label=u"左ノードと同じ")
+    cmds.menuItem(label=u"指定ノード")
+    chain_parent_target = cmds.textFieldGrp(label=u"親ノード名", text="", enable=False)
+
+    chain_orient = cmds.optionMenuGrp(label=u"向き", columnWidth=[(1, 110)])
+    cmds.menuItem(label=u"維持 (none)")
+    cmds.menuItem(label=u"区間方向 (aim)")
+    cmds.menuItem(label=u"コピー (copy)")
+
+    def on_chain_execute(*_):
+        try:
+            orient_idx = cmds.optionMenuGrp(chain_orient, q=True, select=True)
+            orient_value = ["none", "aim", "copy"][orient_idx - 1]
+            parent_idx = cmds.optionMenuGrp(chain_parent_mode, q=True, select=True)
+            if parent_idx == 1:
+                parent_mode = None
+            elif parent_idx == 2:
+                parent_mode = "same"
+            else:
+                parent_text = cmds.textFieldGrp(chain_parent_target, q=True, text=True).strip()
+                parent_mode = parent_text or None
+            result = instanceChain.instance_between_chain(
+                per_segment=cmds.intFieldGrp(chain_count, q=True, value1=True),
+                parent_instances_to=parent_mode,
+                orient=orient_value,
+            )
+            if result:
+                cmds.inViewMessage(
+                    amg=u"<span style='color:#b0ffb0'>%d 個のインスタンスを作成しました。</span>" % len(result),
+                    pos="midCenter",
+                    fade=True,
+                )
+        except RuntimeError as exc:
+            _show_error(str(exc))
+
+    cmds.button(label=u"配置", command=on_chain_execute, bgc=(0.6, 0.8, 0.6))
+    cmds.setParent("..")
+
+    # ------------------------------------------------------------------
+    # Radial tab
+    # ------------------------------------------------------------------
+    radial_tab = cmds.columnLayout(adj=True, rowSpacing=6, columnAttach=("both", 8))
+    cmds.text(label=u"選択：基準 → インスタンス対象", align="left")
+    radial_count = cmds.intFieldGrp(label=u"個数", value1=8, columnWidth=[(1, 100), (2, 60)])
+    radial_axis = cmds.optionMenuGrp(label=u"回転軸", columnWidth=[(1, 100)])
+    cmds.menuItem(label="X")
+    cmds.menuItem(label="Y")
+    cmds.menuItem(label="Z")
+
+    def on_radial_execute(*_):
+        try:
+            axis_idx = cmds.optionMenuGrp(radial_axis, q=True, select=True)
+            axis_value = ["x", "y", "z"][axis_idx - 1]
+            result = instanceRadial.create_instance_circle_with_rotation(
+                num_instances=cmds.intFieldGrp(radial_count, q=True, value1=True),
+                axis=axis_value,
+            )
+            if result:
+                cmds.inViewMessage(
+                    amg=u"<span style='color:#b0ffb0'>%d 個のインスタンスを作成しました。</span>" % len(result),
+                    pos="midCenter",
+                    fade=True,
+                )
+        except RuntimeError as exc:
+            _show_error(str(exc))
+
+    cmds.button(label=u"作成", command=on_radial_execute, bgc=(0.6, 0.8, 0.6))
+    cmds.setParent("..")
+
+    # ------------------------------------------------------------------
+    # Utility tab
+    # ------------------------------------------------------------------
+    util_tab = cmds.columnLayout(adj=True, rowSpacing=8, columnAttach=("both", 8))
+    cmds.text(label=u"選択：最初にテンプレート → 置換したいオブジェクト", align="left")
+
+    def on_replace(*_):
+        try:
+            result = instanceUtilities.replace_with_first_instance()
+            if result:
+                cmds.inViewMessage(
+                    amg=u"<span style='color:#b0ffb0'>%d 個のオブジェクトを置換しました。</span>" % len(result),
+                    pos="midCenter",
+                    fade=True,
+                )
+        except RuntimeError as exc:
+            _show_error(str(exc))
+
+    cmds.button(label=u"選択をテンプレートのインスタンスで置換", command=on_replace, bgc=(0.6, 0.7, 0.9))
+
+    cmds.separator(style="in")
+    cmds.text(label=u"選択：インスタンス化を解除したいオブジェクト", align="left")
+
+    def on_make_unique(*_):
+        result = instanceUtilities.make_selected_unique()
+        if result:
+            cmds.inViewMessage(
+                amg=u"<span style='color:#b0ffb0'>%d 個のインスタンスを解除しました。</span>" % len(result),
+                pos="midCenter",
+                fade=True,
+            )
+
+    cmds.button(label=u"インスタンス解除", command=on_make_unique, bgc=(0.9, 0.7, 0.6))
+    cmds.setParent("..")
+
+    cmds.tabLayout(
+        tabs,
+        edit=True,
+        tabLabel=[
+            (array_tab, u"ライン"),
+            (chain_tab, u"チェーン"),
+            (radial_tab, u"ラジアル"),
+            (util_tab, u"ユーティリティ"),
+        ],
+    )
+
+    cmds.showWindow(win)
+    return win
+
+
+if __name__ == "__main__":
+    show_ui()

--- a/instanceUtilities.py
+++ b/instanceUtilities.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+"""Utility functions for working with instances."""
+
+import maya.cmds as cmds
+
+
+def replace_with_first_instance(template=None, targets=None):
+    """Replace targets with instances of the template transform.
+
+    Args:
+        template (str | None): Transform node to instance. Defaults to first selection.
+        targets (list[str] | None): Target transforms to replace. Defaults to remaining selection.
+
+    Returns:
+        list[str]: Names of created instances.
+    """
+    sel = cmds.ls(sl=True, type="transform", long=True) or []
+    if template is None or targets is None:
+        if len(sel) < 2:
+            cmds.error(u"テンプレートと置換対象を選択してください。（最初にテンプレート）")
+            return []
+        template = template or sel[0]
+        targets = targets or sel[1:]
+
+    if not cmds.objExists(template):
+        cmds.error(u"テンプレートが存在しません。")
+        return []
+
+    created = []
+    for target in targets:
+        if target == template or not cmds.objExists(target):
+            continue
+
+        parent = cmds.listRelatives(target, parent=True, fullPath=True)
+        matrix = cmds.xform(target, q=True, ws=True, m=True)
+        short_name = target.split("|")[-1]
+
+        inst = cmds.instance(template, smartTransform=False)[0]
+        if parent:
+            inst = cmds.parent(inst, parent[0])[0]
+
+        cmds.xform(inst, ws=True, m=matrix)
+
+        cmds.delete(target)
+        inst = cmds.rename(inst, short_name)
+        created.append(inst)
+
+    if created:
+        cmds.select(created, r=True)
+    else:
+        cmds.warning(u"置換されたオブジェクトがありませんでした。")
+
+    return created
+
+
+def make_selected_unique(nodes=None):
+    """Convert selected instances to unique copies by duplicating them."""
+    nodes = nodes or cmds.ls(sl=True, type="transform", long=True) or []
+    if not nodes:
+        cmds.warning(u"インスタンスを解除する対象を選択してください。")
+        return []
+
+    unique_nodes = []
+    for node in nodes:
+        if not cmds.objExists(node):
+            continue
+
+        parent = cmds.listRelatives(node, parent=True, fullPath=True)
+        matrix = cmds.xform(node, q=True, ws=True, m=True)
+        short_name = node.split("|")[-1]
+
+        duplicate = cmds.duplicate(node, name=f"{short_name}_unique#", rr=True, rc=True)[0]
+        if parent:
+            duplicate = cmds.parent(duplicate, parent[0])[0]
+
+        cmds.xform(duplicate, ws=True, m=matrix)
+
+        cmds.delete(node)
+        duplicate = cmds.rename(duplicate, short_name)
+        unique_nodes.append(duplicate)
+
+    if unique_nodes:
+        cmds.select(unique_nodes, r=True)
+
+    return unique_nodes
+
+
+__all__ = ["replace_with_first_instance", "make_selected_unique"]


### PR DESCRIPTION
## Summary
- add a unified Building Tools window covering array, chain, radial instancing and utilities
- add helper functions to replace selections with instances and to uninstance selections
- update the radial instancing tool to return created nodes without auto-launching its UI

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68c9439d9dec832f9fd4b0c3ad5ab12f