### PR TITLE
Add radius control to radial instance creation

### DIFF
--- a/buildingToolsUI.py
+++ b/buildingToolsUI.py
@@ -120,6 +120,7 @@ def show_ui():
     radial_tab = cmds.columnLayout(adj=True, rowSpacing=6, columnAttach=("both", 8))
     cmds.text(label=u"選択：基準 → インスタンス対象", align="left")
     radial_count = cmds.intFieldGrp(label=u"個数", value1=8, columnWidth=[(1, 100), (2, 60)])
+    radial_radius = cmds.intFieldGrp(label=u"半径", value1=10, columnWidth=[(1, 100), (2, 60)])
     radial_axis = cmds.optionMenuGrp(label=u"回転軸", columnWidth=[(1, 100)])
     cmds.menuItem(label="X")
     cmds.menuItem(label="Y")
@@ -132,6 +133,7 @@ def show_ui():
             result = instanceRadial.create_instance_circle_with_rotation(
                 num_instances=cmds.intFieldGrp(radial_count, q=True, value1=True),
                 axis=axis_value,
+                radius=cmds.intFieldGrp(radial_radius, q=True, value1=True),
             )
             if result:
                 cmds.inViewMessage(

--- a/instanceRadial.py
+++ b/instanceRadial.py
@@ -4,12 +4,13 @@
 import maya.cmds as cmds
 
 
-def create_instance_circle_with_rotation(num_instances=8, axis="y"):
+def create_instance_circle_with_rotation(num_instances=8, axis="y", radius=0.0):
     """Create instances of the second selected object around the first.
 
     Args:
         num_instances (int): Number of instances to create around the circle.
         axis (str): Axis to rotate around ("x", "y", or "z").
+        radius (float): Distance to offset along the rotation axis before rotating.
     """
     sel = cmds.ls(selection=True, type="transform")
     if len(sel) < 2:
@@ -34,6 +35,14 @@ def create_instance_circle_with_rotation(num_instances=8, axis="y"):
 
         # Transformの一致をMatchTransform系で行う
         cmds.matchTransform(null, base, pos=True, rot=True)
+
+        if radius:
+            offset_vector = {
+                "x": (radius, 0.0, 0.0),
+                "y": (0.0, radius, 0.0),
+                "z": (0.0, 0.0, radius),
+            }[axis]
+            cmds.move(*offset_vector, null, relative=True, objectSpace=True)
 
         # インスタンス作成・親子付け
         instance = cmds.instance(target, name=f"{target}_inst_{i:02}")[0]


### PR DESCRIPTION
## Summary
- add a radius control to the radial tab UI and send its value to the creation routine
- extend radial instance creation to accept a radius offset and push helper nulls along the selected axis

## Testing
- python -m py_compile buildingToolsUI.py instanceRadial.py

------
https://chatgpt.com/codex/tasks/task_e_68c94f78f1b8832f91684ce0aa0e5b91