### PR TITLE
Add grouping options for instances across tools

### DIFF
--- a/buildingToolsUI.py
+++ b/buildingToolsUI.py
@@ -36,16 +36,28 @@ def show_ui():
     cmds.menuItem(label=u"終点方向 (aim)")
     cmds.menuItem(label=u"コピー (copy)")
     array_parent = cmds.checkBox(label=u"親(始点)の子にする", value=True)
+    array_group = cmds.checkBox(label=u"インスタンスをグループ化", value=False)
+    array_group_name = cmds.textFieldGrp(label=u"グループ名", text="", enable=False)
+
+    def on_array_group_changed(value):
+        cmds.textFieldGrp(array_group_name, e=True, enable=value)
+
+    cmds.checkBox(array_group, e=True, changeCommand=on_array_group_changed)
 
     def on_array_execute(*_):
         try:
             orient_idx = cmds.optionMenuGrp(array_orient, q=True, select=True)
             orient_value = ["none", "aim", "copy"][orient_idx - 1]
+            group_name = None
+            if cmds.checkBox(array_group, q=True, value=True):
+                text = cmds.textFieldGrp(array_group_name, q=True, text=True).strip()
+                group_name = text if text else ""
             result = instanceArray.instance_child_between_parent(
                 count=cmds.intFieldGrp(array_count, q=True, value1=True),
                 include_end=cmds.checkBox(array_include_end, q=True, value=True),
                 orient=orient_value,
                 parent_instances_to_parent=cmds.checkBox(array_parent, q=True, value=True),
+                group_name=group_name,
             )
             if result:
                 cmds.inViewMessage(
@@ -84,6 +96,13 @@ def show_ui():
     cmds.menuItem(label=u"維持 (none)")
     cmds.menuItem(label=u"区間方向 (aim)")
     cmds.menuItem(label=u"コピー (copy)")
+    chain_group = cmds.checkBox(label=u"インスタンスをグループ化", value=False)
+    chain_group_name = cmds.textFieldGrp(label=u"グループ名", text="", enable=False)
+
+    def on_chain_group_changed(value):
+        cmds.textFieldGrp(chain_group_name, e=True, enable=value)
+
+    cmds.checkBox(chain_group, e=True, changeCommand=on_chain_group_changed)
 
     def on_chain_execute(*_):
         try:
@@ -97,10 +116,15 @@ def show_ui():
             else:
                 parent_text = cmds.textFieldGrp(chain_parent_target, q=True, text=True).strip()
                 parent_mode = parent_text or None
+            group_name = None
+            if cmds.checkBox(chain_group, q=True, value=True):
+                text = cmds.textFieldGrp(chain_group_name, q=True, text=True).strip()
+                group_name = text if text else ""
             result = instanceChain.instance_between_chain(
                 per_segment=cmds.intFieldGrp(chain_count, q=True, value1=True),
                 parent_instances_to=parent_mode,
                 orient=orient_value,
+                group_name=group_name,
             )
             if result:
                 cmds.inViewMessage(
@@ -124,14 +148,26 @@ def show_ui():
     cmds.menuItem(label="X")
     cmds.menuItem(label="Y")
     cmds.menuItem(label="Z")
+    radial_group = cmds.checkBox(label=u"インスタンスをグループ化", value=False)
+    radial_group_name = cmds.textFieldGrp(label=u"グループ名", text="", enable=False)
+
+    def on_radial_group_changed(value):
+        cmds.textFieldGrp(radial_group_name, e=True, enable=value)
+
+    cmds.checkBox(radial_group, e=True, changeCommand=on_radial_group_changed)
 
     def on_radial_execute(*_):
         try:
             axis_idx = cmds.optionMenuGrp(radial_axis, q=True, select=True)
             axis_value = ["x", "y", "z"][axis_idx - 1]
+            group_name = None
+            if cmds.checkBox(radial_group, q=True, value=True):
+                text = cmds.textFieldGrp(radial_group_name, q=True, text=True).strip()
+                group_name = text if text else ""
             result = instanceRadial.create_instance_circle_with_rotation(
                 num_instances=cmds.intFieldGrp(radial_count, q=True, value1=True),
                 axis=axis_value,
+                group_name=group_name,
             )
             if result:
                 cmds.inViewMessage(

--- a/instanceRadial.py
+++ b/instanceRadial.py
@@ -4,12 +4,15 @@
 import maya.cmds as cmds
 
 
-def create_instance_circle_with_rotation(num_instances=8, axis="y"):
+def create_instance_circle_with_rotation(num_instances=8, axis="y", group_name=None):
     """Create instances of the second selected object around the first.
 
     Args:
         num_instances (int): Number of instances to create around the circle.
         axis (str): Axis to rotate around ("x", "y", or "z").
+        group_name (str|None):
+            指定時は空グループを新規作成し、生成した null をその子に、
+            null 配下のインスタンスもまとめる。空文字なら "instanceGroup#"。
     """
     sel = cmds.ls(selection=True, type="transform")
     if len(sel) < 2:
@@ -29,11 +32,19 @@ def create_instance_circle_with_rotation(num_instances=8, axis="y"):
     angle_step = 360.0 / float(num_instances)
     created = []
 
+    group_node = None
+    if group_name is not None:
+        name = (group_name or "").strip() or "instanceGroup#"
+        group_node = cmds.group(empty=True, name=name)
+
     for i in range(num_instances):
         null = cmds.group(empty=True, name=f"circle_null_{i:02}")
 
         # Transformの一致をMatchTransform系で行う
         cmds.matchTransform(null, base, pos=True, rot=True)
+
+        if group_node:
+            null = cmds.parent(null, group_node)[0]
 
         # インスタンス作成・親子付け
         instance = cmds.instance(target, name=f"{target}_inst_{i:02}")[0]


### PR DESCRIPTION
## Summary
- add grouping controls to the array, chain, and radial tabs so instances can be grouped with an optional name
- extend the array, chain, and radial instancing utilities to accept an optional group name and parent created nodes into it
- ensure chain grouping respects existing parenting modes and radial grouping collects the helper nulls

## Testing
- not run (requires Maya environment)


------
https://chatgpt.com/codex/tasks/task_e_68c94f8105e8832fb1dc2b6f7269bc4d