### PR TITLE
Add position-based outliner sorting utility

### DIFF
--- a/buildingToolsUI.py
+++ b/buildingToolsUI.py
@@ -454,6 +454,40 @@ def show_ui():
             )
 
     cmds.button(label=u"インスタンス解除", command=on_make_unique, bgc=(0.9, 0.7, 0.6))
+
+    cmds.separator(style="in")
+    cmds.text(label=u"選択：アウトライナ順を並べ替えたいオブジェクト", align="left")
+    util_sort_axis = cmds.optionMenuGrp(
+        label=u"基準軸",
+        columnWidth=[(1, 100)],
+    )
+    cmds.menuItem(label=u"自動 (最大距離)")
+    cmds.menuItem(label="X")
+    cmds.menuItem(label="Y")
+    cmds.menuItem(label="Z")
+    util_sort_desc = cmds.checkBox(label=u"降順 (大きい順)", value=False)
+
+    def on_sort_selected(*_):
+        axis_idx = cmds.optionMenuGrp(util_sort_axis, q=True, select=True)
+        axis_value = {1: "auto", 2: "x", 3: "y", 4: "z"}[axis_idx]
+        descending = cmds.checkBox(util_sort_desc, q=True, value=True)
+        try:
+            result = instanceUtilities.sort_selected_by_position(axis=axis_value, descending=descending)
+            if result:
+                axis_label = {
+                    "auto": u"自動", "x": "X", "y": "Y", "z": "Z"
+                }[axis_value]
+                order_label = u"降順" if descending else u"昇順"
+                cmds.inViewMessage(
+                    amg=u"<span style='color:#b0ffb0'>%d 個のオブジェクトを %s (%s) で並べ替えました。</span>"
+                    % (len(result), axis_label, order_label),
+                    pos="midCenter",
+                    fade=True,
+                )
+        except RuntimeError as exc:
+            _show_error(str(exc))
+
+    cmds.button(label=u"ポジションで並べ替え", command=on_sort_selected, bgc=(0.7, 0.9, 0.7))
     cmds.setParent("..")
 
     cmds.tabLayout(

--- a/instanceUtilities.py
+++ b/instanceUtilities.py
@@ -85,4 +85,144 @@ def make_selected_unique(nodes=None):
     return unique_nodes
 
 
-__all__ = ["replace_with_first_instance", "make_selected_unique"]
+def sort_selected_by_position(nodes=None, axis="auto", descending=False):
+    """Sort selected transforms in the Outliner based on their world position.
+
+    Args:
+        nodes (list[str] | None): Target transforms. Defaults to current selection.
+        axis (str): Axis to sort by. ``"x"``, ``"y"``, ``"z"`` or ``"auto"``.
+            ``"auto"`` picks the axis with the largest positional spread per parent.
+        descending (bool): If True, reverse the sort order.
+
+    Returns:
+        list[str]: Nodes reordered in their new Outliner sequence.
+    """
+
+    axis = (axis or "auto").lower()
+    axis_map = {"x": 0, "y": 1, "z": 2}
+    if axis not in axis_map and axis != "auto":
+        cmds.error(u"axis には auto / x / y / z のいずれかを指定してください。")
+        return []
+
+    nodes = nodes or cmds.ls(sl=True, type="transform", long=True) or []
+    nodes = [node for node in nodes if cmds.objExists(node)]
+    if len(nodes) < 2:
+        if not nodes:
+            cmds.warning(u"並べ替えるオブジェクトを選択してください。")
+        else:
+            cmds.warning(u"並べ替えには 2 つ以上のオブジェクトを選択してください。")
+        return []
+
+    parent_groups = {}
+    parent_order = []
+    for node in nodes:
+        parent = cmds.listRelatives(node, parent=True, fullPath=True)
+        parent = parent[0] if parent else None
+        if parent not in parent_groups:
+            parent_groups[parent] = []
+            parent_order.append(parent)
+        parent_groups[parent].append(node)
+
+    ordered_selection = []
+    processed_count = 0
+    epsilon = 1e-6
+
+    def _choose_axis(data):
+        if axis != "auto":
+            return axis_map[axis]
+        ranges = []
+        for idx in range(3):
+            coords = [pos[idx] for _, pos in data]
+            if coords:
+                axis_range = max(coords) - min(coords)
+            else:
+                axis_range = 0.0
+            ranges.append(axis_range)
+        max_range = max(ranges) if ranges else 0.0
+        if max_range <= epsilon:
+            return None
+        return ranges.index(max_range)
+
+    for parent in parent_order:
+        group = [node for node in parent_groups.get(parent, []) if cmds.objExists(node)]
+        if len(group) < 2:
+            ordered_selection.extend(group)
+            continue
+
+        data = []
+        for node in group:
+            pos = cmds.xform(node, q=True, ws=True, t=True)
+            data.append((node, pos))
+
+        axis_index = _choose_axis(data)
+        if axis_index is None:
+            sorted_nodes = sorted(group)
+        else:
+            secondary_axes = [idx for idx in range(3) if idx != axis_index]
+
+            def _sort_key(item):
+                pos = item[1]
+                key_values = [round(pos[axis_index], 6)]
+                key_values.extend(round(pos[idx], 6) for idx in secondary_axes)
+                key_values.append(item[0])
+                return tuple(key_values)
+
+            sorted_nodes = [item[0] for item in sorted(data, key=_sort_key)]
+
+        if descending:
+            sorted_nodes.reverse()
+
+        if parent:
+            children = cmds.listRelatives(parent, children=True, type="transform", fullPath=True) or []
+        else:
+            children = cmds.ls(assemblies=True, long=True) or []
+
+        selected_set = set(group)
+        queue = list(sorted_nodes)
+        final_order = []
+        queue_index = 0
+        for child in children:
+            if child in selected_set:
+                if queue_index < len(queue):
+                    final_order.append(queue[queue_index])
+                    queue_index += 1
+            else:
+                final_order.append(child)
+        if queue_index < len(queue):
+            # Append any nodes that lost their parent between evaluation and reorder.
+            final_order.extend(queue[queue_index:])
+
+        if not final_order:
+            continue
+
+        if final_order == children:
+            ordered_selection.extend(sorted_nodes)
+            processed_count += len(sorted_nodes)
+            continue
+
+        try:
+            for child in reversed(final_order):
+                cmds.reorder(child, front=True)
+        except RuntimeError:
+            label = parent or u"ルート"
+            cmds.warning(u"%s 配下の並べ替えに失敗しました。" % label)
+            ordered_selection.extend(group)
+            continue
+
+        ordered_selection.extend(sorted_nodes)
+        processed_count += len(sorted_nodes)
+
+    if processed_count:
+        cmds.select(ordered_selection, r=True)
+        return ordered_selection
+
+    # Nothing was reordered (e.g. each group had 1 child)
+    cmds.warning(u"並べ替え可能なオブジェクトが見つかりませんでした。")
+    return []
+
+
+__all__ = [
+    "replace_with_first_instance",
+    "make_selected_unique",
+    "sort_selected_by_position",
+]


### PR DESCRIPTION
## Summary
- add a utility function that reorders selected transforms in the Outliner based on their world positions, including auto axis detection and descending support
- extend the Building Tools utility tab with controls to choose the axis/order and a button to trigger the positional sort, displaying feedback when applied

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68ca0a40b770832f97a9e5b986dde3a6