### PR TITLE
Add bounding-box count array mode

### DIFF
--- a/instanceArray.py
+++ b/instanceArray.py
@@ -5,8 +5,18 @@ import maya.cmds as cmds
 _AXIS_INDICES = {"x": 0, "y": 1, "z": 2}
 
 
-def _compute_bbox_spacing(node, axis):
-    """Return the world-space size of ``node`` along the given local ``axis``."""
+def _compute_bbox_axis_info(node, axis):
+    """Return spacing and direction data for ``node`` along ``axis``.
+
+    Args:
+        node (str): Transform to sample.
+        axis (str): Local axis name (``"x"``, ``"y"``, ``"z"``).
+
+    Returns:
+        dict|None: ``{"spacing": float, "direction": tuple[float, float, float]}``
+            in world-space. ``None`` when the bounding box information cannot be
+            obtained.
+    """
 
     if not cmds.objExists(node):
         return None
@@ -28,7 +38,7 @@ def _compute_bbox_spacing(node, axis):
     max_value = bbox[axis_index + 3]
     base_size = abs(max_value - min_value)
     if base_size <= 1e-6:
-        return 0.0
+        return {"spacing": 0.0, "direction": None}
 
     try:
         matrix = cmds.xform(node, q=True, ws=True, matrix=True)
@@ -43,9 +53,20 @@ def _compute_bbox_spacing(node, axis):
     vec = axis_vectors[axis]
     length = math.sqrt(vec[0] * vec[0] + vec[1] * vec[1] + vec[2] * vec[2])
     if length <= 1e-6:
-        return 0.0
+        return {"spacing": 0.0, "direction": None}
 
-    return base_size * length
+    spacing = base_size * length
+    direction = (vec[0] / length, vec[1] / length, vec[2] / length)
+    return {"spacing": spacing, "direction": direction}
+
+
+def _compute_bbox_spacing(node, axis):
+    """Return the world-space size of ``node`` along the given local ``axis``."""
+
+    info = _compute_bbox_axis_info(node, axis)
+    if not info:
+        return None
+    return info["spacing"]
 
 
 def instance_child_between_parent(
@@ -61,6 +82,7 @@ def instance_child_between_parent(
     bbox_axis="x",
     alternate_scale=False,
     alternate_scale_axis="x",
+    bbox_count_mode=False,
 ):
     """
     親(始点)と子(終点)の間に、子をインスタンス化して等間隔配置する。
@@ -85,32 +107,157 @@ def instance_child_between_parent(
         bbox_axis (str): use_bbox_spacing=True のときに参照するローカル軸（"x"/"y"/"z"）。
         alternate_scale (bool): True の場合、インスタンスのスケールを交互に反転させる。
         alternate_scale_axis (str): スケールを反転させる軸（"x"/"y"/"z"）。
+        bbox_count_mode (bool): True の場合、use_bbox_spacing=True と組み合わせて
+            親を指定せずにバウンディングボックス幅を使った個数指定モードで配置する。
+            parent を省略した場合も自動的にこのモードになります。
     Returns:
         list[str]: 作成したインスタンスノード名のリスト
     """
     sel = cmds.ls(sl=True, type="transform", long=True) or []
-    if parent is None or child is None:
-        if len(sel) < 2:
-            cmds.error(u"親→子の順で2つ選択するか、引数で parent と child を指定してください。")
-        parent = parent or sel[0]
-        child  = child  or sel[1]
+    selection_parent = sel[0] if len(sel) >= 1 else None
+    selection_child = sel[1] if len(sel) >= 2 else None
 
-    if not (cmds.objExists(parent) and cmds.objExists(child)):
-        cmds.error(u"指定した parent または child が存在しません。")
+    if child is None:
+        if selection_child is not None:
+            child = selection_child
+        elif selection_parent is not None:
+            child = selection_parent
 
-    # ワールド座標の取得
-    p_pos = cmds.xform(parent, q=True, ws=True, t=True)
-    c_pos = cmds.xform(child,  q=True, ws=True, t=True)
+    if parent is None and selection_parent is not None and selection_parent != child:
+        parent = selection_parent
 
-    # グループ化
+    if child is None or not cmds.objExists(child):
+        cmds.error(u"指定した child が存在しません。")
+
+    if parent is not None and not cmds.objExists(parent):
+        cmds.error(u"指定した parent が存在しません。")
+
+    count_mode = bool(use_bbox_spacing and (bbox_count_mode or parent is None))
+
+    if not count_mode and parent is None:
+        cmds.error(u"親→子の順で2つ選択するか、引数で parent と child を指定してください。")
+
+    c_pos = cmds.xform(child, q=True, ws=True, t=True)
+    p_pos = None
+    if not count_mode:
+        p_pos = cmds.xform(parent, q=True, ws=True, t=True)
+
+    child_parent = None
+    parents = cmds.listRelatives(child, parent=True, f=True) or []
+    if parents:
+        child_parent = parents[0]
+
+    parent_target = None
+    if parent_instances_to_parent:
+        if count_mode:
+            if parent and cmds.objExists(parent):
+                parent_target = parent
+            elif child_parent and cmds.objExists(child_parent):
+                parent_target = child_parent
+        else:
+            if parent and cmds.objExists(parent):
+                parent_target = parent
+
     group_node = None
     if group_name is not None:
         name = (group_name or "").strip() or "instanceGroup#"
         group_node = cmds.group(em=True, name=name)
-        if parent_instances_to_parent and parent and cmds.objExists(parent):
-            group_node = cmds.parent(group_node, parent)[0]
+        if parent_target:
+            group_node = cmds.parent(group_node, parent_target)[0]
 
-    # 補間ステップの決定
+    alternate_axis = None
+    base_scale_values = None
+    if alternate_scale:
+        alternate_axis = (alternate_scale_axis or "x").lower()
+        if alternate_axis not in _AXIS_INDICES:
+            alternate_axis = "x"
+        try:
+            base_scale_values = cmds.xform(child, q=True, r=True, s=True)
+        except RuntimeError:
+            base_scale_values = None
+        if not base_scale_values or len(base_scale_values) < 3:
+            base_scale_values = [1.0, 1.0, 1.0]
+        else:
+            base_scale_values = list(base_scale_values[:3])
+
+    if count_mode:
+        info = _compute_bbox_axis_info(child, bbox_axis)
+        if not info:
+            cmds.warning(u"バウンディングボックスの取得に失敗しました。距離指定で再試行してください。")
+            return []
+        spacing_value = info["spacing"]
+        direction = info["direction"]
+        if spacing_value is None or spacing_value <= 1e-6 or not direction:
+            cmds.warning(u"選択したローカル軸でのサイズがゼロのため、配置できません。")
+            return []
+        try:
+            count_value = int(count)
+        except (TypeError, ValueError):
+            cmds.warning(u"count は整数を指定してください。何も作成しません。")
+            return []
+        if count_value < 0:
+            count_value = 0
+        multipliers = list(range(1, count_value + 1))
+        if include_end:
+            multipliers.append(count_value + 1)
+        if not multipliers:
+            cmds.warning(u"count は 1 以上にしてください。何も作成しません。")
+            return []
+
+        created = []
+        aim_helper = None
+        try:
+            for index, step in enumerate(multipliers):
+                pos = [
+                    c_pos[i] + direction[i] * spacing_value * step
+                    for i in range(3)
+                ]
+                inst = cmds.instance(child, smartTransform=False)[0]
+
+                if group_node:
+                    inst = cmds.parent(inst, group_node)[0]
+                elif parent_instances_to_parent and parent_target:
+                    inst = cmds.parent(inst, parent_target)[0]
+
+                cmds.xform(inst, ws=True, t=pos)
+
+                if orient == "copy":
+                    rot = cmds.xform(child, q=True, ws=True, ro=True)
+                    cmds.xform(inst, ws=True, ro=rot)
+                elif orient == "aim":
+                    if aim_helper is None:
+                        aim_helper = cmds.spaceLocator()[0]
+                    target_pos = [pos[i] + direction[i] for i in range(3)]
+                    cmds.xform(aim_helper, ws=True, t=target_pos)
+                    ac = cmds.aimConstraint(
+                        aim_helper,
+                        inst,
+                        aimVector=(0, 0, 1),
+                        upVector=(0, 1, 0),
+                        worldUpType="scene",
+                    )[0]
+                    cmds.delete(ac)
+
+                if alternate_axis and base_scale_values:
+                    axis_index = _AXIS_INDICES[alternate_axis]
+                    flip = -1 if (index % 2 == 1) else 1
+                    scale_values = list(base_scale_values)
+                    scale_values[axis_index] = base_scale_values[axis_index] * flip
+                    axis_attrs = ["scaleX", "scaleY", "scaleZ"]
+                    for attr_index, attr_name in enumerate(axis_attrs):
+                        value = scale_values[attr_index]
+                        try:
+                            cmds.setAttr(f"{inst}.{attr_name}", value)
+                        except RuntimeError:
+                            pass
+
+                created.append(inst)
+        finally:
+            if aim_helper and cmds.objExists(aim_helper):
+                cmds.delete(aim_helper)
+
+        return created
+
     spacing_value = None
     use_spacing = False
     if use_bbox_spacing:
@@ -164,45 +311,28 @@ def instance_child_between_parent(
         cmds.warning(u"指定条件では配置するインスタンスがありません。")
         return []
 
-    alternate_axis = None
-    base_scale_values = None
-    if alternate_scale:
-        alternate_axis = (alternate_scale_axis or "x").lower()
-        if alternate_axis not in _AXIS_INDICES:
-            alternate_axis = "x"
-        try:
-            base_scale_values = cmds.xform(child, q=True, r=True, s=True)
-        except RuntimeError:
-            base_scale_values = None
-        if not base_scale_values or len(base_scale_values) < 3:
-            base_scale_values = [1.0, 1.0, 1.0]
-        else:
-            base_scale_values = list(base_scale_values[:3])
-
     created = []
     for index, t in enumerate(steps):
         pos = [p_pos[i] + (c_pos[i] - p_pos[i]) * t for i in range(3)]
         inst = cmds.instance(child, smartTransform=False)[0]
 
-        # 親子付け
         if group_node:
             inst = cmds.parent(inst, group_node)[0]
-        elif parent_instances_to_parent:
-            inst = cmds.parent(inst, parent)[0]
+        elif parent_instances_to_parent and parent_target:
+            inst = cmds.parent(inst, parent_target)[0]
 
-        # 配置
         cmds.xform(inst, ws=True, t=pos)
 
-        # 回転処理
         if orient == "copy":
             rot = cmds.xform(child, q=True, ws=True, ro=True)
             cmds.xform(inst, ws=True, ro=rot)
         elif orient == "aim":
             ac = cmds.aimConstraint(
-                child, inst,
+                child,
+                inst,
                 aimVector=(0, 0, 1),
                 upVector=(0, 1, 0),
-                worldUpType="scene"
+                worldUpType="scene",
             )[0]
             cmds.delete(ac)
 
@@ -228,3 +358,4 @@ def instance_child_between_parent(
 # 親→子を選択してから実行
 # instance_child_between_parent(count=5, include_end=True, orient="aim")
 # instance_child_between_parent(spacing=2.5, include_end=False)
+# instance_child_between_parent(use_bbox_spacing=True, bbox_count_mode=True, count=4)


### PR DESCRIPTION
## Summary
- support creating line arrays from a single template using bounding box size and an explicit count
- expose the new mode in the UI, enabling the count field and clarifying the selection hint

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cb470465d8832f9eff1c47f153d262